### PR TITLE
fix: Do not create a separate KMS key for Performance Insights if it …

### DIFF
--- a/modules/rds_cluster_instance/README.md
+++ b/modules/rds_cluster_instance/README.md
@@ -38,6 +38,6 @@
 ## Resources
 
 - resource.aws_rds_cluster_instance.main (modules/rds_cluster_instance/main.tf#1)
-- resource.random_password.master_password (modules/rds_cluster_instance/main.tf#64)
-- resource.random_string.master_username (modules/rds_cluster_instance/main.tf#59)
+- resource.random_password.master_password (modules/rds_cluster_instance/main.tf#66)
+- resource.random_string.master_username (modules/rds_cluster_instance/main.tf#61)
 <!-- END_TF_DOCS -->

--- a/modules/rds_cluster_instance/main.tf
+++ b/modules/rds_cluster_instance/main.tf
@@ -19,7 +19,7 @@ resource "aws_rds_cluster_instance" "main" {
 
   # Performance Insights
   performance_insights_enabled          = var.performance_insights_enabled
-  performance_insights_kms_key_id       = module.kms.key_arn
+  performance_insights_kms_key_id       = var.performance_insights_enabled ? module.kms[0].key_arn : null
   performance_insights_retention_period = var.performance_insights_retention_period
 
   # Network
@@ -49,6 +49,8 @@ module "db_enhanced_monitoring" {
 }
 
 module "kms" {
+  count = var.performance_insights_enabled ? 1 : 0
+
   source  = "geekcell/kms/aws"
   version = ">= 1.0.0, < 2.0.0"
 


### PR DESCRIPTION
…is not used at all

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

A separate CMK was always created for Performance Insights, but if Performance Insights are disabled, no CMK needs to be created.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [x] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
