### PR TITLE
feat: Remove ServerlessV2 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ such as extended backups, user management, and autoscaling.
 | <a name="input_port"></a> [port](#input\_port) | The port on which the DB accepts connections. | `number` | `3306` | no |
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. | `string` | `"00:00-02:30"` | no |
 | <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range during which system maintenance can occur, in (UTC). | `string` | `"Mon:03:00-Mon:04:30"` | no |
-| <a name="input_serverlessv2_scaling_configuration"></a> [serverlessv2\_scaling\_configuration](#input\_serverlessv2\_scaling\_configuration) | The scaling configuration of the Aurora Serverless DB cluster. | <pre>object({<br>    max_capacity = number<br>    min_capacity = number<br>  })</pre> | <pre>{<br>  "max_capacity": null,<br>  "min_capacity": null<br>}</pre> | no |
 | <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Storage type. | `string` | `"aurora"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the AWS RDS Cluster Instance. | `map(any)` | `{}` | no |
 | <a name="input_vpc_security_group_ids_rds_cluster"></a> [vpc\_security\_group\_ids\_rds\_cluster](#input\_vpc\_security\_group\_ids\_rds\_cluster) | List of VPC security groups to associate with the RDS Proxy. | `list(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -37,9 +37,6 @@ module "rds_cluster" {
   engine_mode    = var.engine_mode
   database_name  = var.database_name
 
-  # Serverless
-  serverlessv2_scaling_configuration = var.serverlessv2_scaling_configuration
-
   # Network
   db_subnet_group_name   = var.database_subnet_group_name
   vpc_security_group_ids = var.vpc_security_group_ids_rds_cluster

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -21,7 +21,7 @@
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the DB instance should have deletion protection enabled. | `bool` | `false` | no |
 | <a name="input_enabled_cloudwatch_logs_exports"></a> [enabled\_cloudwatch\_logs\_exports](#input\_enabled\_cloudwatch\_logs\_exports) | Set of log types to enable for exporting to CloudWatch logs. | `list(string)` | n/a | yes |
 | <a name="input_engine"></a> [engine](#input\_engine) | The engine to use. | `string` | `"aurora-mysql"` | no |
-| <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode) | The database engine mode. | `string` | n/a | yes |
+| <a name="input_engine_mode"></a> [engine\_mode](#input\_engine\_mode) | The database engine mode. | `string` | `"provisioned"` | no |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The engine version to use. | `string` | n/a | yes |
 | <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The name of your final DB snapshot when this DB cluster is deleted. | `string` | `"final-snapshot"` | no |
 | <a name="input_iam_database_authentication_enabled"></a> [iam\_database\_authentication\_enabled](#input\_iam\_database\_authentication\_enabled) | Specifies whether or not mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled. | `bool` | `false` | no |
@@ -31,7 +31,6 @@
 | <a name="input_preferred_backup_window"></a> [preferred\_backup\_window](#input\_preferred\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. | `string` | `"00:00-02:30"` | no |
 | <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range during which system maintenance can occur, in (UTC). | `string` | `"Mon:03:00-Mon:04:30"` | no |
 | <a name="input_replication_source_identifier"></a> [replication\_source\_identifier](#input\_replication\_source\_identifier) | ARN of the source DB cluster or DB instance if this DB cluster is created as a Read Replica. | `string` | `null` | no |
-| <a name="input_serverlessv2_scaling_configuration"></a> [serverlessv2\_scaling\_configuration](#input\_serverlessv2\_scaling\_configuration) | The scaling configuration of the Aurora Serverless DB cluster. | <pre>object({<br>    max_capacity = optional(number)<br>    min_capacity = optional(number)<br>  })</pre> | n/a | yes |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final DB snapshot is created before the DB cluster is deleted. | `bool` | `false` | no |
 | <a name="input_source_region"></a> [source\_region](#input\_source\_region) | The source region for an encrypted replica DB cluster. | `string` | `null` | no |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | Specifies whether the DB cluster is encrypted. | `bool` | `true` | no |
@@ -57,7 +56,7 @@
 ## Resources
 
 - resource.aws_rds_cluster.main (modules/rds_cluster/main.tf#1)
-- resource.random_password.master_password (modules/rds_cluster/main.tf#107)
-- resource.random_string.master_username (modules/rds_cluster/main.tf#101)
+- resource.random_password.master_password (modules/rds_cluster/main.tf#112)
+- resource.random_string.master_username (modules/rds_cluster/main.tf#106)
 - data source.aws_availability_zones.available (modules/rds_cluster/data.tf#1)
 <!-- END_TF_DOCS -->

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -56,7 +56,7 @@
 ## Resources
 
 - resource.aws_rds_cluster.main (modules/rds_cluster/main.tf#1)
-- resource.random_password.master_password (modules/rds_cluster/main.tf#112)
-- resource.random_string.master_username (modules/rds_cluster/main.tf#106)
+- resource.random_password.master_password (modules/rds_cluster/main.tf#107)
+- resource.random_string.master_username (modules/rds_cluster/main.tf#101)
 - data source.aws_availability_zones.available (modules/rds_cluster/data.tf#1)
 <!-- END_TF_DOCS -->

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -63,15 +63,6 @@ resource "aws_rds_cluster" "main" {
   # Security
   deletion_protection = var.deletion_protection
 
-  # Serverless
-  dynamic "serverlessv2_scaling_configuration" {
-    for_each = var.serverlessv2_scaling_configuration == null ? [] : [1]
-    content {
-      max_capacity = var.serverlessv2_scaling_configuration.max_capacity
-      min_capacity = var.serverlessv2_scaling_configuration.min_capacity
-    }
-  }
-
   # Tags
   tags = merge(
     var.tags,
@@ -80,6 +71,15 @@ resource "aws_rds_cluster" "main" {
       "ServiceType" = "cluster"
     }
   )
+
+  # Once you start the Aurora cluster as "provisioned", then change it to ServerlessV2, then change it back to
+  # "provisioned", then according to AWS Support it is no longer possible to remove this setting - it is just
+  # no longer used. If this has happened to you, too: this is why we ignore changes to this setting.
+  lifecycle {
+    ignore_changes = [
+      serverlessv2_scaling_configuration
+    ]
+  }
 }
 
 module "autoscaling" {

--- a/modules/rds_cluster/variables.tf
+++ b/modules/rds_cluster/variables.tf
@@ -100,6 +100,7 @@ variable "engine" {
 }
 
 variable "engine_mode" {
+  default     = "provisioned"
   description = "The database engine mode."
   type        = string
 }
@@ -155,14 +156,6 @@ variable "replication_source_identifier" {
   default     = null
   description = "ARN of the source DB cluster or DB instance if this DB cluster is created as a Read Replica."
   type        = string
-}
-
-variable "serverlessv2_scaling_configuration" {
-  description = "The scaling configuration of the Aurora Serverless DB cluster."
-  type = object({
-    max_capacity = optional(number)
-    min_capacity = optional(number)
-  })
 }
 
 variable "source_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -199,18 +199,6 @@ variable "port" {
   type        = number
 }
 
-variable "serverlessv2_scaling_configuration" {
-  default = {
-    max_capacity = null
-    min_capacity = null
-  }
-  description = "The scaling configuration of the Aurora Serverless DB cluster."
-  type = object({
-    max_capacity = number
-    min_capacity = number
-  })
-}
-
 variable "storage_type" {
   default     = "aurora"
   description = "Storage type."


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

We have removed the ServerlessV2 feature as it is still too young to be released.

There are also a few pitfalls in its use and proper configuration.

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [x] Label as `breaking` if this is a large fundamental change
- [x] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [x] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
